### PR TITLE
fix: use correct data from api response

### DIFF
--- a/src/views/account-detail/index.js
+++ b/src/views/account-detail/index.js
@@ -262,7 +262,7 @@ class AccountLatest extends Component {
 
   async addNode() {
       const {node, stakedImgSrc, unstakingImgSrc, unstakedImgSrc} = this.state;
-
+      
       let obj = {
           stakingStatus: "UNSTAKED",
           stakingStatusImg: unstakedImgSrc,
@@ -271,7 +271,7 @@ class AccountLatest extends Component {
 
       if (node !== undefined) {
           // Update the staked amount
-          obj.stakedTokens = (Number(node.stakedTokens.toString()) / 1000000).toFixed(3);
+          obj.stakedTokens = (Number(node.tokens.toString()) / 1000000).toFixed(3);
 
           if (node.status === 1) {
               obj.stakingStatus = "UNSTAKING";
@@ -306,7 +306,7 @@ class AccountLatest extends Component {
       const nodeOrError = await dataSource.getNode(addressHex);
 
       if (nodeOrError !== undefined) {
-          this.setState({node: nodeOrError.node});
+          this.setState({node: nodeOrError});
           this.addNode();
       }
 


### PR DESCRIPTION
Fixes #202.

The problem was that the response from Pocket-JS was different than the Portal API response.

Before the migration, when a node was retrieved from dataSource it returned an object with a property called `node`. Now, this `node` property doesn't exist, and the whole response from the dataSource is what this `node` property used to return.

After adjusting the state accordingly, it works as expected.

![image](https://user-images.githubusercontent.com/40803711/127091566-6be7b77d-73ad-4cd6-9456-e5bf497d73cf.png)


