### PR TITLE
feat: point staging deployment to testnet domain

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,67 @@
+name: Staging Deployment
+
+on:
+  push:
+    branches: [ staging ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 12.15.0 ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: NPM install
+      run: npm install
+    - name: Production build
+      run: npm run build
+      env:
+       REACT_APP_CLIENT_PASSPHRASE: ${{ secrets.WALLET_PRODUCTION_CLIENT_PASSPHRASE }}
+       REACT_APP_CLIENT_PUBLIC_KEY: ${{ secrets.WALLET_PRODUCTION_CLIENT_PUBLIC_KEY }}
+       REACT_APP_CLIENT_PRIVATE_KEY: ${{ secrets.WALLET_PRODUCTION_CLIENT_PRIVATE_KEY }}
+       REACT_APP_WALLET_APP_PUBLIC_KEY: ${{ secrets.WALLET_PRODUCTION_APP_PUBLIC_KEY }}
+       REACT_APP_WALLET_APP_AAT_SIGNATURE: ${{ secrets.WALLET_PRODUCTION_APP_AAT_SIGNATURE }}
+       REACT_APP_POKT_USD_VALUE: ${{ secrets.POKT_USD_MARKET_PRICE }}
+       REACT_APP_SECURE_LS_ENCRYPTION_SECRET: ${{ secrets.SECURE_LS_ENCRYPTION_SECRET }}
+       REACT_APP_SECURE_LS_ENCODING_TYPE: "aes"
+       REACT_APP_SECURE_LS_IS_COMPRESSION: true
+       REACT_APP_AAT_VERSION: "0.0.1"
+       REACT_APP_MAX_DISPATCHERS: 0
+       REACT_APP_PROVIDER_TYPE: "http"
+       REACT_APP_BLOCK_EXPLORER_BASE_URL: "https://explorer.pokt.network"
+       REACT_APP_DASHBOARD_BASE_URL: "https://dashboard.pokt.network"
+       REACT_APP_BUY_POKT_BASE_URL: "https://forum.pokt.network/t/secondary-markets-for-pokt/629"
+       REACT_APP_CHAIN: "0001"
+       REACT_APP_CHAIN_ID: "mainnet"
+       REACT_APP_BLOCK_TIME: "900000"
+       REACT_APP_MAX_TRANSACTION_LIST_COUNT: "5000"
+       REACT_APP_MIN_TRANSACTION_LIST_COUNT: "200"
+       REACT_APP_TX_FEE: "10000"
+       REACT_APP_SESSION_LENGTH: "30"
+       REACT_APP_GATEWAY_BASE_URL: "http://gateway.pokt.network/v1/lb/60a2ac11b1747c6552385c61"
+       REACT_APP_HTTP_TIMEOUT: 0
+       REACT_APP_HTTP_HEADERS: '{"Content-Type": "application/json"}'
+       REACT_APP_USE_LEGACY_CODEC: 'false'
+    - name: Deploy to S3
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_TESTNET_BUCKET_NAME }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        SOURCE_DIR: "build"
+    - name: Clear CloudFront Cache
+      uses: awact/cloudfront-action@master
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        DISTRIBUTION_ID: ${{ secrets.AWS_TESTNET_DISTRIBUTION_ID }}
+

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -2,7 +2,7 @@ name: Testnet Deployment
 
 on:
   push:
-    branches: [ staging ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates the workflows as follows;

- `wallet.testnet.pokt.network` will serve a staging (mainnet) deployment.
- The testnet workflow will only be triggered on pushes to master (disabled, basically as workflow changes won't reach master).

This is a temporary workaround to be able to access a staging deployment as quickly as possible. Ideally, we will setup a `wallet.staging.pokt.network` domain for staging deployments and having all of them separate. 