### PR TITLE
Convert address inputs to lowercase to fix signature verification issue

### DIFF
--- a/src/context/transportContext.jsx
+++ b/src/context/transportContext.jsx
@@ -105,8 +105,8 @@ export function TransportProvider({ children }) {
         type,
         value: {
           amount: amount.toString(),
-          from_address: userAddress,
-          to_address: toAddress,
+          from_address: userAddress.toLowerCase(),
+          to_address: toAddress.toString().toLowerCase(),
         },
       },
     };


### PR DESCRIPTION
Stumbled upon a bug while trying to send POKT from my ledger device in which any capitalized letter in the "Send to Address" input field will spit back a signature verification error after signing the tx from ledger. This seems to relate to an older issue (#182 ). As a suggested fix for this, I converted the address values to lowercase strings.

cc: @kutoft 